### PR TITLE
Trigger 'slack:finished' calback after 'deploy:migrations'

### DIFF
--- a/lib/capistrano/slack.rb
+++ b/lib/capistrano/slack.rb
@@ -11,6 +11,7 @@ module Capistrano
         before 'deploy', 'slack:starting'
         before 'deploy:migrations', 'slack:starting'
         after 'deploy',  'slack:finished'
+        after 'deploy:migrations',  'slack:finished'
 
         set :deployer do
           ENV['GIT_AUTHOR_NAME'] || `git config user.name`.chomp


### PR DESCRIPTION
Adds a call to `slack:finished` after a migration deploy with Capistrano
