### PR TITLE
Allow parse options

### DIFF
--- a/lib/capistrano/slack.rb
+++ b/lib/capistrano/slack.rb
@@ -12,7 +12,8 @@ module Capistrano
         'channel' => fetch(:slack_room),
         'username' => fetch(:slack_username, ''),
         'text' => announcement,
-        'icon_emoji' => fetch(:slack_emoji, '')
+        'icon_emoji' => fetch(:slack_emoji, ''),
+        'parse' => fetch(:slack_parse, '')
         }.to_json
       end
 


### PR DESCRIPTION
This allows sending parse=full which will link usernames for mentions.

https://api.slack.com/docs/formatting