### PR TITLE
Fixes `slack_webhook_url' not found when following the instructions.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,10 +20,9 @@ require 'capistrano/slack'
 
 #in deploy.rb 
 # required
-set :slack_token, "webhook_token" # comes from inbound webhook integration
-set :slack_room, "#general"
-set :slack_subdomain, "kohactive" # if your subdomain is kohactive.slack.com
-
+set :slack_webhook_url, "webhook_token" # slack's incoming webhook
+set :slack_room,        "#general"      # slacks's room name
+set :slack_subdomain,   "kohactive"     # If your subdomain is kohactive.slack.com
 
 before 'deploy', 'slack:starting'
 after 'deploy',  'slack:finished'

--- a/README.markdown
+++ b/README.markdown
@@ -24,9 +24,7 @@ set :slack_webhook_url, "webhook_token" # slack's incoming webhook
 set :slack_room,        "#general"      # slacks's room name
 set :slack_subdomain,   "kohactive"     # If your subdomain is kohactive.slack.com
 
-before 'deploy', 'slack:starting'
-after 'deploy',  'slack:finished'
-
+before 'deploy', 'slack:starting'       # Triggers 'slack:finished' after the deploy is finished.
 
 # optional
 set :slack_application, "Rocketman"
@@ -58,4 +56,3 @@ namespace :slack do
     before "deploy:migrate", "slack:migration:start"
     after  "deploy:migrate", "slack:migration:end"
 ```
-


### PR DESCRIPTION
```
be cap myapp deploy -s branch=master
~.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/activesupport-4.1.1/lib/active_support/values/time_zone.rb:285: warning: circular argument reference - now
Fetching references from origin repository ...
~.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/capistrano-2.15.5/lib/capistrano/configuration/variables.rb:82:in `block in fetch': 
`slack_webhook_url' not found (IndexError)
```
